### PR TITLE
Handle a possible null reference when changing pages in a SPA

### DIFF
--- a/src/ResponsiveNav.tsx
+++ b/src/ResponsiveNav.tsx
@@ -63,6 +63,9 @@ const ResponsiveNav: ResponsiveNavComponent = React.forwardRef(
     };
 
     const handleResize = () => {
+      if (!containerRef.current) {
+        return;
+      }
       const items = containerRef.current.querySelectorAll('.rs-nav-item');
       const containerWidth = _.getWidth(containerRef.current);
       const list = [];


### PR DESCRIPTION
I found that, when changing pages in an SPA (React + Next.js in this case), sometimes `handleResize` is called after the container element is unmounted from the DOM (so `containerRef.current` is null), but before the responsive nav component is removed from the VDOM, causing an error during page change. Adding a null check fixes this.